### PR TITLE
Add post image upload helper

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -159,6 +159,18 @@ export async function uploadBannerImage(file: File): Promise<{ publicUrl: string
   }
 }
 
+/**
+ * Uploads a post image to the "posts" bucket and returns its storage path.
+ */
+export async function uploadPostImage(file: File, path: string): Promise<string> {
+  const { data, error } = await supabase
+    .storage
+    .from('posts')
+    .upload(path, file, { upsert: true });
+  if (error) throw error;
+  return data.path;
+}
+
 // Delete image from storage
 export async function deleteImage(bucket: string, filePath: string): Promise<boolean> {
   try {


### PR DESCRIPTION
## Summary
- add `uploadPostImage` to storage helpers
- adjust CreatePostScreen to use new helper

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fe8d0eb883299ba11901cb8f21a1