### PR TITLE
Remove blue checkmarks and improve profile link validation

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -35,18 +35,31 @@ export function transformProfileToUser(profile: any): User {
 
 // Check if a profile URL is reachable
 export async function validateProfileUrl(url: string): Promise<boolean> {
+  let reachable = false
+
   try {
     const res = await fetch(url, { method: 'HEAD' })
-    if (res.ok) return true
-  } catch (e) {
-    // ignore and try GET
+    reachable = res.ok
+  } catch {
+    // ignore network/CORS errors
   }
-  try {
-    const res = await fetch(url, { method: 'GET' })
-    return res.ok
-  } catch (e) {
-    return false
+
+  if (!reachable) {
+    try {
+      const res = await fetch(url, { method: 'GET' })
+      reachable = res.ok
+    } catch {
+      // ignore network/CORS errors
+    }
   }
+
+  if (reachable) return true
+
+  const linkedin = /^https?:\/\/(www\.)?linkedin\.com\/in\/[A-Za-z0-9\-_]+\/?$/
+  const instagram = /^https?:\/\/(www\.)?instagram\.com\/[A-Za-z0-9\._]+\/?$/
+  const twitter = /^https?:\/\/(www\.)?twitter\.com\/[A-Za-z0-9_]+\/?$/
+
+  return linkedin.test(url) || instagram.test(url) || twitter.test(url)
 }
 
 // Re-export uploadProfileImage for backward compatibility

--- a/src/components/common/SocialLinks.tsx
+++ b/src/components/common/SocialLinks.tsx
@@ -11,35 +11,31 @@ interface Props {
 }
 
 export const SocialLinks: React.FC<Props> = ({ links, className = '' }) => {
+  const platforms = [
+    { url: links.Twitter, Icon: IconBrandX, title: 'X (formerly Twitter)' },
+    { url: links.Instagram, Icon: IconBrandInstagram, title: 'Instagram' },
+    { url: links.LinkedIn, Icon: IconBrandLinkedin, title: 'LinkedIn' }
+  ]
+
   return (
     <div className={`flex items-center gap-6 ${className}`}>
-      <a
-        href={links.Twitter}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-gray-400 hover:text-white transition-colors"
-        title="X (formerly Twitter)"
-      >
-        <IconBrandX size={24} />
-      </a>
-      <a
-        href={links.Instagram}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-gray-400 hover:text-white transition-colors"
-        title="Instagram"
-      >
-        <IconBrandInstagram size={24} />
-      </a>
-      <a
-        href={links.LinkedIn}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-gray-400 hover:text-white transition-colors"
-        title="LinkedIn"
-      >
-        <IconBrandLinkedin size={24} />
-      </a>
+      {platforms.map(
+        ({ url, Icon, title }) =>
+          url &&
+          url.trim() !== '' &&
+          url !== '#' && (
+            <a
+              key={title}
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-400 hover:text-white transition-colors"
+              title={title}
+            >
+              <Icon size={24} />
+            </a>
+          )
+      )}
     </div>
-  );
-};
+  )
+}

--- a/src/components/social/SocialAccountsSection.tsx
+++ b/src/components/social/SocialAccountsSection.tsx
@@ -6,7 +6,7 @@ import {
   IconBrandLinkedin, 
   IconBrandX
 } from '@tabler/icons-react';
-import { CheckCircleIcon, LinkIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { LinkIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { supabase } from '../../lib/supabase';
 import { transformProfileToUser } from '../../../lib/utils';
 
@@ -139,16 +139,11 @@ export const SocialAccountsSection: React.FC<Props> = ({ user, onUserUpdate }) =
                   <div className="min-w-0 flex-1">
                     <h3 className="font-medium text-white">{provider.name}</h3>
                     {isConnected ? (
-                      <div className="flex items-center gap-2 mt-1">
-                        <CheckCircleIcon className="w-4 h-4 text-green-500" />
-                        <p className="text-sm text-green-400 truncate">
-                          {currentUrl}
-                        </p>
-                      </div>
-                    ) : (
-                      <p className="text-sm text-gray-500">
-                        Not connected
+                      <p className="text-sm text-green-400 mt-1 truncate">
+                        {currentUrl}
                       </p>
+                    ) : (
+                      <p className="text-sm text-gray-500">Not connected</p>
                     )}
                   </div>
                 </div>

--- a/src/components/social/SocialAuthButton.tsx
+++ b/src/components/social/SocialAuthButton.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { CheckCircleIcon, LinkIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { LinkIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { SocialProvider } from '../../types';
 
 interface Props {
   provider: SocialProvider;
   isConnected: boolean;
-  isVerified: boolean;
   profileUrl?: string;
   onConnect: () => void;
 }
@@ -13,23 +12,17 @@ interface Props {
 export const SocialAuthButton: React.FC<Props> = ({
   provider,
   isConnected,
-  isVerified,
   profileUrl,
   onConnect
 }) => {
   const IconComponent = provider.icon;
 
-  const getButtonText = () => {
-    if (isConnected && isVerified) return 'Edit Link';
-    return 'Add Link';
-  };
+  const getButtonText = () => (isConnected ? 'Edit Link' : 'Add Link');
 
-  const getButtonStyle = () => {
-    if (isConnected && isVerified) {
-      return 'bg-blue-600 hover:bg-blue-700 border-blue-500';
-    }
-    return 'bg-gray-700 hover:bg-gray-600 border-gray-600';
-  };
+  const getButtonStyle = () =>
+    isConnected
+      ? 'bg-blue-600 hover:bg-blue-700 border-blue-500'
+      : 'bg-gray-700 hover:bg-gray-600 border-gray-600';
 
   return (
     <div className="flex items-center justify-between p-4 bg-gray-800 border border-gray-600 rounded-lg">
@@ -37,13 +30,8 @@ export const SocialAuthButton: React.FC<Props> = ({
         <IconComponent size={24} className="text-gray-300" />
         <div className="min-w-0 flex-1">
           <h3 className="font-medium text-white">{provider.name}</h3>
-          {isConnected && isVerified && profileUrl && (
-            <div className="flex items-center gap-2 mt-1">
-              <CheckCircleIcon className="w-4 h-4 text-green-500" />
-              <p className="text-sm text-green-400 truncate">
-                {profileUrl}
-              </p>
-            </div>
+          {isConnected && profileUrl && (
+            <p className="text-sm text-green-400 mt-1 truncate">{profileUrl}</p>
           )}
           {!isConnected && (
             <p className="text-sm text-gray-500">


### PR DESCRIPTION
## Summary
- add regex fallback when network check fails in `validateProfileUrl`
- show social icons only when links exist
- drop all verified badge icons
- simplify social edit buttons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685531eb072083298c5227866e6121ea