### PR TITLE
Handle duplicate signup errors

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -39,9 +39,19 @@ export const sendSignupOTP = async (email: string): Promise<AuthResponse> => {
       
       // Handle specific Supabase errors
       if (error.message.includes('User already registered')) {
-        return { 
-          success: false, 
-          error: 'An account with this email already exists. Please sign in instead or use "Forgot password?" if you need to reset your password.' 
+        return {
+          success: false,
+          error: 'An account with this email already exists. Please sign in instead or use "Forgot password?" if you need to reset your password.'
+        }
+      }
+
+      if (
+        error.message.includes('Database error saving new user') ||
+        error.message.includes('duplicate key value')
+      ) {
+        return {
+          success: false,
+          error: 'An account with this email already exists. Please sign in instead or use "Forgot password?" if you need to reset your password.'
         }
       }
       

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -108,7 +108,11 @@ export const LoginScreen: React.FC<Props> = ({ onLogin }) => {
       } else {
         console.error('OTP send failed:', result.error);
         // Check if the error indicates an existing account
-        if (result.error && result.error.includes('already exists')) {
+        if (
+          result.error &&
+          (result.error.includes('already exists') ||
+            result.error.includes('Database error saving new user'))
+        ) {
           // Switch to login view and pre-fill email
           setCurrentView('login');
           setError('An account with this email already exists. Please sign in below.');


### PR DESCRIPTION
## Summary
- handle database uniqueness errors when requesting a signup OTP
- redirect to login when signup OTP fails for existing users

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554a0c096c8329b98792051a80c053